### PR TITLE
Implement cloud events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <java.version>17</java.version>
     <dwca-io.version>2.7</dwca-io.version>
     <jaxb2-maven-plugin.version>2.5.0</jaxb2-maven-plugin.version>
+    <cloudevents.version>2.3.0</cloudevents.version>
   </properties>
 
   <repositories>
@@ -72,7 +73,21 @@
       <artifactId>jaxb2-maven-plugin</artifactId>
       <version>${jaxb2-maven-plugin.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-api</artifactId>
+      <version>${cloudevents.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-core</artifactId>
+      <version>${cloudevents.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cloudevents</groupId>
+      <artifactId>cloudevents-kafka</artifactId>
+      <version>${cloudevents.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/eu/dissco/webflux/demo/configuration/KafkaProducerConfig.java
+++ b/src/main/java/eu/dissco/webflux/demo/configuration/KafkaProducerConfig.java
@@ -1,6 +1,8 @@
 package eu.dissco.webflux.demo.configuration;
 
 import eu.dissco.webflux.demo.properties.KafkaProperties;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.kafka.CloudEventSerializer;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
@@ -19,7 +21,7 @@ public class KafkaProducerConfig {
   private final KafkaProperties properties;
 
   @Bean
-  public ProducerFactory<String, String> producerFactory() {
+  public ProducerFactory<String, CloudEvent> producerFactory() {
     Map<String, Object> configProps = new HashMap<>();
     configProps.put(
         ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -29,12 +31,12 @@ public class KafkaProducerConfig {
         StringSerializer.class);
     configProps.put(
         ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-        StringSerializer.class);
+        CloudEventSerializer.class);
     return new DefaultKafkaProducerFactory<>(configProps);
   }
 
   @Bean
-  public KafkaTemplate<String, String> kafkaTemplate() {
+  public KafkaTemplate<String, CloudEvent> kafkaTemplate() {
     return new KafkaTemplate<>(producerFactory());
   }
 }

--- a/src/main/java/eu/dissco/webflux/demo/properties/KafkaProperties.java
+++ b/src/main/java/eu/dissco/webflux/demo/properties/KafkaProperties.java
@@ -17,7 +17,7 @@ public class KafkaProperties {
   @NotBlank
   private String topic;
 
-  private int numberOfPartitions = 1;
+  private int numberOfPartitions = 4;
 
   private short numberOfReplications = 1;
 

--- a/src/main/java/eu/dissco/webflux/demo/properties/OpenDSProperties.java
+++ b/src/main/java/eu/dissco/webflux/demo/properties/OpenDSProperties.java
@@ -15,4 +15,6 @@ public class OpenDSProperties {
   @NotBlank
   private String serviceName;
 
+  private String evenType = "dissco/translator-event";
+
 }

--- a/src/main/java/eu/dissco/webflux/demo/service/CloudEventService.java
+++ b/src/main/java/eu/dissco/webflux/demo/service/CloudEventService.java
@@ -1,0 +1,43 @@
+package eu.dissco.webflux.demo.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.webflux.demo.domain.OpenDSWrapper;
+import eu.dissco.webflux.demo.properties.OpenDSProperties;
+import eu.dissco.webflux.demo.properties.WebClientProperties;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import java.net.URI;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CloudEventService {
+
+  private final ObjectMapper mapper;
+  private final OpenDSProperties openDSProperties;
+  private final WebClientProperties webClientProperties;
+
+  public CloudEvent createCloudEvent(OpenDSWrapper openDS) {
+    try {
+      return CloudEventBuilder.v1()
+          .withId(UUID.randomUUID().toString())
+          .withType(openDSProperties.getEvenType())
+          .withSource(URI.create(webClientProperties.getEndpoint()))
+          .withSubject(openDSProperties.getServiceName())
+          .withTime(OffsetDateTime.now())
+          .withDataContentType("application/json")
+          .withData(mapper.writeValueAsBytes(openDS))
+          .build();
+    } catch (JsonProcessingException e) {
+      log.error("Unable to deserialize the object: {}", openDS);
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/eu/dissco/webflux/demo/service/webclients/BioCaseService.java
+++ b/src/main/java/eu/dissco/webflux/demo/service/webclients/BioCaseService.java
@@ -13,6 +13,7 @@ import eu.dissco.webflux.demo.domain.Image;
 import eu.dissco.webflux.demo.domain.OpenDSWrapper;
 import eu.dissco.webflux.demo.properties.OpenDSProperties;
 import eu.dissco.webflux.demo.properties.WebClientProperties;
+import eu.dissco.webflux.demo.service.CloudEventService;
 import eu.dissco.webflux.demo.service.KafkaService;
 import eu.dissco.webflux.demo.service.RorService;
 import freemarker.template.Configuration;
@@ -24,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -59,6 +61,7 @@ public class BioCaseService implements WebClientInterface {
   private final Configuration configuration;
   private final KafkaService kafkaService;
   private final RorService rorService;
+  private final CloudEventService cloudEventService;
 
 
   @Override
@@ -86,7 +89,10 @@ public class BioCaseService implements WebClientInterface {
       updateStartAtParameter(templateProperties);
       recordList.stream()
           .filter(openDS -> openDS.getAuthoritative().getMaterialType().equals("PreservedSpecimen"))
-          .map(this::addRoR).forEach(kafkaService::sendMessage);
+          .map(this::addRoR)
+          .map(cloudEventService::createCloudEvent)
+          .filter(Objects::nonNull)
+          .forEach(kafkaService::sendMessage);
     }
   }
 

--- a/src/main/java/eu/dissco/webflux/demo/service/webclients/DwcaService.java
+++ b/src/main/java/eu/dissco/webflux/demo/service/webclients/DwcaService.java
@@ -9,6 +9,7 @@ import eu.dissco.webflux.demo.domain.OpenDSWrapper;
 import eu.dissco.webflux.demo.properties.DwcaProperties;
 import eu.dissco.webflux.demo.properties.OpenDSProperties;
 import eu.dissco.webflux.demo.properties.WebClientProperties;
+import eu.dissco.webflux.demo.service.CloudEventService;
 import eu.dissco.webflux.demo.service.KafkaService;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +54,7 @@ public class DwcaService implements WebClientInterface {
   private final OpenDSProperties openDSProperties;
   private final DwcaProperties dwcaProperties;
   private final KafkaService kafkaService;
+  private final CloudEventService cloudEventService;
 
   @Override
   public void retrieveData() {
@@ -64,6 +67,8 @@ public class DwcaService implements WebClientInterface {
       var openDsRecords = mapToOpenDS(file);
       openDsRecords.values().stream()
           .filter(this::checkMaterialType)
+          .map(cloudEventService::createCloudEvent)
+          .filter(Objects::nonNull)
           .forEach(kafkaService::sendMessage);
     } catch (IOException e) {
       log.error("Failed to open output stream for download file", e);

--- a/src/test/java/eu/dissco/webflux/demo/service/CloudEventServiceTest.java
+++ b/src/test/java/eu/dissco/webflux/demo/service/CloudEventServiceTest.java
@@ -1,0 +1,53 @@
+package eu.dissco.webflux.demo.service;
+
+import static eu.dissco.webflux.demo.util.TestUtil.ENDPOINT;
+import static eu.dissco.webflux.demo.util.TestUtil.EVENT_TYPE;
+import static eu.dissco.webflux.demo.util.TestUtil.SERVICE_NAME;
+import static eu.dissco.webflux.demo.util.TestUtil.testCloudEvent;
+import static eu.dissco.webflux.demo.util.TestUtil.testOpenDSWrapper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.webflux.demo.properties.OpenDSProperties;
+import eu.dissco.webflux.demo.properties.WebClientProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CloudEventServiceTest {
+
+  private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+  @Mock
+  private OpenDSProperties openDSProperties;
+  @Mock
+  private WebClientProperties webClientProperties;
+
+  private CloudEventService service;
+
+  @BeforeEach
+  void setup() {
+    service = new CloudEventService(mapper, openDSProperties, webClientProperties);
+  }
+
+  @Test
+  void testCreateCloudEvent() throws JsonProcessingException {
+    // Given
+    given(openDSProperties.getServiceName()).willReturn(SERVICE_NAME);
+    given(openDSProperties.getEvenType()).willReturn(EVENT_TYPE);
+    given(webClientProperties.getEndpoint()).willReturn(ENDPOINT);
+
+    // When
+    var result = service.createCloudEvent(testOpenDSWrapper());
+
+    // Then
+    assertThat(result).usingRecursiveComparison().ignoringFields("id", "time")
+        .isEqualTo(testCloudEvent());
+  }
+
+}

--- a/src/test/java/eu/dissco/webflux/demo/service/webclients/GeoCaseServiceTest.java
+++ b/src/test/java/eu/dissco/webflux/demo/service/webclients/GeoCaseServiceTest.java
@@ -1,6 +1,7 @@
 package eu.dissco.webflux.demo.service.webclients;
 
 import static eu.dissco.webflux.demo.util.TestUtil.loadResourceFile;
+import static eu.dissco.webflux.demo.util.TestUtil.testCloudEvent;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,6 +15,7 @@ import eu.dissco.webflux.demo.domain.Image;
 import eu.dissco.webflux.demo.domain.OpenDSWrapper;
 import eu.dissco.webflux.demo.properties.OpenDSProperties;
 import eu.dissco.webflux.demo.properties.WebClientProperties;
+import eu.dissco.webflux.demo.service.CloudEventService;
 import eu.dissco.webflux.demo.service.KafkaService;
 import eu.dissco.webflux.demo.service.RorService;
 import java.io.IOException;
@@ -50,12 +52,15 @@ class GeoCaseServiceTest {
   private RorService rorService;
   @Mock
   private KafkaService kafkaService;
+  @Mock
+  private CloudEventService cloudEventService;
 
   private GeoCaseService service;
 
   @BeforeEach
   void setup() {
-    service = new GeoCaseService(client, properties, openDSProperties, rorService, kafkaService);
+    service = new GeoCaseService(client, properties, openDSProperties, rorService, kafkaService,
+        cloudEventService);
   }
 
   @Test
@@ -67,7 +72,9 @@ class GeoCaseServiceTest {
     given(openDSProperties.getServiceName()).willReturn("geocase-api-service");
     given(properties.getItemsPerRequest()).willReturn(1);
     given(rorService.getRoRId(anyString())).willReturn("Unknown");
-    var expected = givenExpected();
+    var expected = testCloudEvent();
+    given(cloudEventService.createCloudEvent(eq(givenExpected()))).willReturn(expected);
+
 
     // When
     service.retrieveData();
@@ -79,20 +86,20 @@ class GeoCaseServiceTest {
 
   private OpenDSWrapper givenExpected() {
     return OpenDSWrapper.builder().authoritative(
-        Authoritative.builder()
-            .midslevel(1)
-            .physicalSpecimenId("638-222")
-            .name("Algae (informal)")
-            .materialType("Fossil")
-            .curatedObjectID("https://geocollections.info/specimen/289080")
-            .institutionCode("University of Tartu, Natural History Museum")
-            .institution("Unknown")
-            .build()
-    ).images(
-        List.of(Image.builder().imageUri(
-                "https://files.geocollections.info/medium/4d/59/4d59cfd2-1c22-408c-88e1-111b1364470d.jpg")
-            .build())
-    ).sourceId("geocase-api-service")
+            Authoritative.builder()
+                .midslevel(1)
+                .physicalSpecimenId("638-222")
+                .name("Algae (informal)")
+                .materialType("Fossil")
+                .curatedObjectID("https://geocollections.info/specimen/289080")
+                .institutionCode("University of Tartu, Natural History Museum")
+                .institution("Unknown")
+                .build()
+        ).images(
+            List.of(Image.builder().imageUri(
+                    "https://files.geocollections.info/medium/4d/59/4d59cfd2-1c22-408c-88e1-111b1364470d.jpg")
+                .build())
+        ).sourceId("geocase-api-service")
         .unmapped(mapper.createObjectNode()).build();
   }
 

--- a/src/test/java/eu/dissco/webflux/demo/util/TestUtil.java
+++ b/src/test/java/eu/dissco/webflux/demo/util/TestUtil.java
@@ -1,14 +1,27 @@
 package eu.dissco.webflux.demo.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.dissco.webflux.demo.domain.Authoritative;
 import eu.dissco.webflux.demo.domain.Image;
 import eu.dissco.webflux.demo.domain.OpenDSWrapper;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.core.builder.CloudEventBuilder;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.core.io.ClassPathResource;
 
 public class TestUtil {
+
+  public static final String EVENT_ID = "6474f841-b548-48d9-9a53-a9fd3df84084";
+  public static final String SERVICE_NAME = "translator-test-service";
+  public static final String ENDPOINT = "https://endpoint.com";
+  public static final String EVENT_TYPE = "dissco/translator-event";
 
   public static final String INSTITUTION_NAME = "Naturalis Biodiversity Center";
   public static final String ROR_INSTITUTION = "https://ror.org/0566bfb96";
@@ -17,6 +30,7 @@ public class TestUtil {
   public static final String BASIS_OF_RECORD = "Herbarium sheet";
   public static final String SCIENTIFIC_NAME = "Argyrolobium zanonii (Turra) P.W.Ball";
   public static final String IMAGE_URI = "https://medialib.naturalis.nl/file/id/L.3892015/format/large";
+  private static final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
 
   public static String loadResourceFile(String fileName) throws IOException {
     return new String(new ClassPathResource(fileName).getInputStream()
@@ -26,6 +40,24 @@ public class TestUtil {
   public static OpenDSWrapper testOpenDSWrapper() {
     return OpenDSWrapper.builder().authoritative(testAuthoritative()).images(List.of(testImage()))
         .sourceId("translator-service").build();
+  }
+
+  public static CloudEvent testCloudEvent()
+      throws JsonProcessingException {
+    return testCloudEvent(testOpenDSWrapper());
+  }
+
+  public static CloudEvent testCloudEvent(OpenDSWrapper openDSWrapper)
+      throws JsonProcessingException {
+    return CloudEventBuilder.v1()
+        .withId(EVENT_ID)
+        .withSource(URI.create(ENDPOINT))
+        .withSubject(SERVICE_NAME)
+        .withTime(OffsetDateTime.now(ZoneOffset.UTC))
+        .withType(EVENT_TYPE)
+        .withDataContentType("application/json")
+        .withData(mapper.writeValueAsBytes(testOpenDSWrapper()))
+        .build();
   }
 
   public static Authoritative testAuthoritative() {


### PR DESCRIPTION
Use Cloud Events for internal communication.
Cloud events provides a consistent way in using events.
This enables us to better manage our metadata, follow the events through the system and enable others to connect to our queue.